### PR TITLE
Add nogui build tag to exclude the raylib GUI

### DIFF
--- a/internal/rayui/rayui.go
+++ b/internal/rayui/rayui.go
@@ -1,3 +1,5 @@
+//go:build !nogui
+
 package rayui
 
 import (

--- a/internal/rayui/rayui_stub.go
+++ b/internal/rayui/rayui_stub.go
@@ -1,0 +1,17 @@
+//go:build nogui
+
+package rayui
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jdefrancesco/dskDitto/internal/dmap"
+	"github.com/jdefrancesco/dskDitto/internal/dupview"
+)
+
+// Launch is a stub for builds without the raylib GUI (-tags nogui).
+func Launch(_ *dmap.Dmap, _ dupview.ApplyOptions) {
+	fmt.Fprintln(os.Stderr, "dskDitto was built without GUI support")
+	os.Exit(1)
+}

--- a/internal/rayui/rayui_test.go
+++ b/internal/rayui/rayui_test.go
@@ -1,3 +1,5 @@
+//go:build !nogui
+
 package rayui
 
 import (


### PR DESCRIPTION
Building with -tags nogui compiles `dskDitto` without the raylib GUI: --gui then prints a short notice and exits. This lets packagers ship the TUI without pulling in cgo and the X11/Wayland/GL toolchain the vendored GLFW needs at build time (raylib is the only cgo dependency on Linux). The default build is unchanged.